### PR TITLE
Ensure entrypoint is set to terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ steps:
     branches: "master"
     plugins:
       - artifacts#v1.2.0:
-          download: "tfplan"
+          download:
+            from: "tfplan"
+            to: "terraform/tfplan"
       - echoboomer/terraform#v1.2.23:
           apply_only: true
           init_args:

--- a/hooks/command
+++ b/hooks/command
@@ -190,6 +190,8 @@ function terraform-run() {
 
     echo "--- :terraform: :buildkite: :floppy_disk: Listing directory contents for record keeping."
     ls -al .
+  else
+    export TF_DIFF=true
   fi
 
   if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -59,6 +59,7 @@ function terraform-bin() {
   docker_args+=(
     "--rm"
     "-it"
+    "--entrypoint" "terraform"
     "-e" "SSH_AUTH_SOCK"
     "-v" "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
     "-v" "$PWD:/svc"


### PR DESCRIPTION
We want to change the docker image to one with a different entrypoint, but for this plugin the entrypoint has to be terraform. This PR ensures the entrypoint will be overridden so it is always terraform.